### PR TITLE
Refines the sponsorship/co-host roles of outside agencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
             <div class="banner-tagline">
               <h1>Hack for Savannah 2017</h1>
               <p>Sept. 22-24, 2017 @ Bull Street Labs</p>
-                    <p>An <a href="https://opensavannah.org">Open Savannah</a> and <a href="http://codebasesav.com"> Codebase</a> event with support from SEDA to mark Code for America's annual <a href="http://ndoch.us"> National Day of Civic Hacking</a></p>
+                    <p>An <a href="https://opensavannah.org">Open Savannah</a> event with support from SEDA to mark Code for America's annual <a href="http://ndoch.us"> National Day of Civic Hacking</a></p>
 
             </div>
           </div>
@@ -159,7 +159,7 @@
             <h5>Want to help build <a href="https://github.com/opensavannah">stuff that matters</a>? Want to have a <a href="https://photos.app.goo.gl/D2hkIXsEdCM0twwO2">fun time</a> meeting <a href="https://www.meetup.com/OpenSavannah/members/">new. interesting, and creative people</a> from the Savannah area? Want a chance to win up to $3,500 doing it?</h5>
               
               <p>Open Savannah’s first-annual “Hack for Savannah” civic hackathon (see <a href="https://opensavannah.org/what-is-a-civic-hackathon">What is a civic hackathon?”</a>) is absolutely <strong>free to participate in</strong>, and the civic technological solutions you build could end up being officially adopted by the City of Savannah or Chatham County.</p>
-                <p>The hackathon is being held in collaboration with mobile app agency <a href="http://codebasesav.com">Codebase</a> to mark <a href="http://codeforamerica.org">Code for America</a>'s annual <a href="http://ndoch.us">National Day of Civic Hacking</a>, an annual day of action to convene coders, bureaucrats, data scientists, journalists, user experience designers, and community activists to tackle big problems.</p>
+                <p>The hackathon is being held to mark <a href="http://codeforamerica.org">Code for America</a>'s annual <a href="http://ndoch.us">National Day of Civic Hacking</a>, an annual day of action to convene coders, bureaucrats, data scientists, journalists, user experience designers, and community activists to tackle big problems.</p>
                 <h6>What is a hackathon?</h6>
                 <p>Simply put, and as the name might suggest, hackathons are hacking marathons. This means that we get together for a weekend to create new projects from the ideation stage to functional (or at least semi-functional) prototypes. It’s also a great excuse to eat food, drink lots of coffee, hang out with friends and meet new people.</p>
             </div>
@@ -171,7 +171,7 @@
           <div class="info_wrap">
                 <i class="fa fa-fire-extinguisher" aria-hidden="true"></i>
                 <h5>Who We Are</h5>
-                <p><a href="https://opensavannah.org">Open Savannah</a>, the official local brigade of <a href="http://codeforamerica.org">Code for America</a>. We're a diverse and inclusive mix of civic-minded individuals from a variety of backgrounds who share the common belief that we can make government work better "by the people, for the people, of the people, in the 21st Century." As an added bonus, the team from <a href="http://codebasesav.com">Codebase</a>, a local mobile app development agency, will also be pitching in their help with the event.</p>
+                <p><a href="https://opensavannah.org">Open Savannah</a>, the official local brigade of <a href="http://codeforamerica.org">Code for America</a>. We're a diverse and inclusive mix of civic-minded individuals from a variety of backgrounds who share the common belief that we can make government work better "by the people, for the people, of the people, in the 21st Century."</p>
             </div>
       </div>
         
@@ -401,7 +401,7 @@
                   </div>
                   <div class="schedule_info">
                     <h4>How The Weekend Will Work</h4>
-                    <p>Aleshia Howell, founder of mobile app development agency Codebase, will go over with participants the structure and timeline of the weekend. Groups may wish to have a quick strategy talk after Aleshia finishes up. Bull Street Labs' doors will close at midnight and reopen at 8 a.m. </p>
+                    <p>To kick things off, our organizers will go over with participants the structure and timeline of the weekend. After that, groups are free to start planning their strategy and moving forward. Bull Street Labs' doors will close at midnight and reopen at 8 a.m. </p>
                   </div>
                 </div>
               </div>
@@ -728,6 +728,9 @@ Open Savannah aims to create a safe space for participants of all skill levels, 
         </div>
         <div class="item">
           <div class="vertical_align_md"> <a href="http://codebasesav.com"><img src="https://s3.amazonaws.com/cvlassets/Screen%20Shot%202017-09-01%20at%206.24.35%20PM.png" alt="image"></a> </div>
+        </div>
+        <div class="item">
+          <div class="vertical_align_md"> <a href="http://oak.works"><img src="http://oak.works/img/logos/oakworks.svg" alt="Oak.Works" width="265"></a> </div>
         </div>
         <div class="item">
           <div class="vertical_align_md"> <a href="http://creativecoast.organization"><img src="https://s3.amazonaws.com/cvlassets/creative-coast_1.jpg" alt="image"></a> </div>


### PR DESCRIPTION
Changes the role of Codebase in the event
Adds Oak.Works to the list of sponsors